### PR TITLE
Fixed crash due to dataURI as src

### DIFF
--- a/lib/ngx-gallery-preview.component.ts
+++ b/lib/ngx-gallery-preview.component.ts
@@ -160,7 +160,7 @@ export class NgxGalleryPreviewComponent implements OnChanges {
     }
 
     getSafeUrl(image: string): SafeUrl {
-        return this.sanitization.bypassSecurityTrustUrl(image);
+        return image.substr(0, 10) === 'data:image' ? image : this.sanitization.bypassSecurityTrustUrl(image);
     }
 
     private isKeyboardNext(e): boolean {


### PR DESCRIPTION
Fixed a case where entering dataURI as src results in repeated loading of image and ultimately crashes browser.