### PR TITLE
Add Custom Action Icons and a previewChange event

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ You can read more about this issue [here](https://github.com/angular/material2/i
 - `previewZoom` | Type: `boolean` | Default value: `false` - enables or disables zoom in and zoom out
 - `previewZoomStep` | Type: `number` | Default value: `0.1` - step for zoom change
 - `previewZoomMax` | Type: `number` | Default value: `2` - max value for zoom
-- `previewZoomMin` | Type: `number` | Default value: `0.5` - min value for zoom 
+- `previewZoomMin` | Type: `number` | Default value: `0.5` - min value for zoom
 
 - `arrowPrevIcon` | Type: `string` | Default value: `'fa fa-arrow-circle-left'` - icon for prev arrow
 - `arrowNextIcon` | Type: `string` | Default value: `'fa fa-arrow-circle-right'` - icon for next arrow
@@ -123,6 +123,7 @@ You can read more about this issue [here](https://github.com/angular/material2/i
 - `spinnerIcon` | Type: `string` | Default value: `'fa fa-spinner fa-pulse fa-3x fa-fw'` - icon for spinner
 - `zoomInIcon` | Type: `string` | Default value: `'fa fa-search-plus'` - icon for zoom in
 - `zoomOutIcon` | Type: `string` | Default value: `'fa fa-search-minus'` - icon for zoom out
+- `actions` | Type: `NgxGalleryAction[]` | Default value: `[]` - Array of new custom actions that will be added to the left of the current close/zoom/fullscreen icons
 
 # NgxGalleryImage
 - `small` | Type: `string | SafeResourceUrl` - url used in thumbnails
@@ -149,11 +150,18 @@ You can read more about this issue [here](https://github.com/angular/material2/i
 - `Column` (default)
 - `Row`
 
+# NgxGalleryAction
+- `icon` | Type: `string` - icon for custom action
+- `disabled` | Type: `boolean` | Default value: `false` - if the icon should be disabled
+- `titleText` | Type: `string` | Default value: `''` - text to set the title attribute to
+- `onClick` | Type: `(event: Event) => void` - Output function to call when custom action icon is clicked
+
 # Events
 - `change` - triggered on image change
 - `imagesReady` - triggered when images length > 0
 - `previewOpen` - triggered on preview open
 - `previewClose` - triggered on preview close
+- `previewChange` - triggered on preview image change
 
 # Methods
 - `show(index: number): void` - shows image at index
@@ -189,11 +197,11 @@ import { NgxGalleryOptions, NgxGalleryImage, NgxGalleryAnimation } from 'ngx-gal
     templateUrl: './app.component.html',
     styleUrls: ['./app.component.scss'],
 })
-export class AppComponent implements OnInit {    
+export class AppComponent implements OnInit {
     galleryOptions: NgxGalleryOptions[];
     galleryImages: NgxGalleryImage[];
 
-    ngOnInit(): void {     
+    ngOnInit(): void {
 
         this.galleryOptions = [
             {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { NgModule, ModuleWithProviders } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { HammerGestureConfig, HAMMER_GESTURE_CONFIG } from '@angular/platform-browser';
 
+import { NgxGalleryActionComponent } from './ngx-gallery-action.component';
 import { NgxGalleryArrowsComponent } from './ngx-gallery-arrows.component';
 import { NgxGalleryImageComponent } from './ngx-gallery-image.component';
 import { NgxGalleryThumbnailsComponent } from './ngx-gallery-thumbnails.component';
@@ -9,6 +10,7 @@ import { NgxGalleryPreviewComponent } from './ngx-gallery-preview.component';
 import { NgxGalleryComponent } from './ngx-gallery.component';
 
 export * from './ngx-gallery.component';
+export * from './ngx-gallery-action.component';
 export * from './ngx-gallery-image.component';
 export * from './ngx-gallery-thumbnails.component';
 export * from './ngx-gallery-preview.component';
@@ -23,28 +25,29 @@ export * from './ngx-gallery-order.model';
 export * from './ngx-gallery-ordered-image.model';
 
 export class CustomHammerConfig extends HammerGestureConfig  {
-  overrides = <any>{
-      'pinch': { enable: false },
-      'rotate': { enable: false }
-  };
+    overrides = <any>{
+        'pinch': { enable: false },
+        'rotate': { enable: false }
+    };
 }
 
 @NgModule({
-  imports: [
-    CommonModule
-  ],
-  declarations: [
-    NgxGalleryArrowsComponent,
-    NgxGalleryImageComponent,
-    NgxGalleryThumbnailsComponent,
-    NgxGalleryPreviewComponent,
-    NgxGalleryComponent
-  ],
-  exports: [
-    NgxGalleryComponent
-  ],
-  providers: [
-    { provide: HAMMER_GESTURE_CONFIG, useClass: CustomHammerConfig }
-  ]
+    imports: [
+        CommonModule
+    ],
+    declarations: [
+        NgxGalleryActionComponent,
+        NgxGalleryArrowsComponent,
+        NgxGalleryImageComponent,
+        NgxGalleryThumbnailsComponent,
+        NgxGalleryPreviewComponent,
+        NgxGalleryComponent
+    ],
+    exports: [
+        NgxGalleryComponent
+    ],
+    providers: [
+        { provide: HAMMER_GESTURE_CONFIG, useClass: CustomHammerConfig }
+    ]
 })
 export class NgxGalleryModule {}

--- a/src/ngx-gallery-action.component.spec.ts
+++ b/src/ngx-gallery-action.component.spec.ts
@@ -1,0 +1,44 @@
+import { } from 'jasmine';
+import { TestBed, ComponentFixture } from '@angular/core/testing';
+import { NgxGalleryActionComponent } from './';
+
+describe('NgxGalleryActionComponent', () => {
+    let fixture: ComponentFixture<NgxGalleryActionComponent>;
+    let comp: NgxGalleryActionComponent;
+    let el, icon;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            declarations: [ NgxGalleryActionComponent ],
+        })
+
+        fixture = TestBed.createComponent(NgxGalleryActionComponent);
+        comp = fixture.componentInstance;
+        comp.icon = 'test';
+
+        fixture.detectChanges();
+
+        el = fixture.debugElement.nativeElement;
+        icon = el.querySelector('.ngx-gallery-icon');
+    });
+
+    it('should emit event onClick after click', () => {
+        spyOn(comp.onClick, 'emit');
+        icon.click();
+        expect(comp.onClick.emit).toHaveBeenCalled();
+    });
+
+    it('should not emit event onClick after click if action is disabled', () => {
+        comp.disabled = true;
+        spyOn(comp.onClick, 'emit');
+        icon.click();
+        expect(comp.onClick.emit).not.toHaveBeenCalled();
+    });
+
+    it('should set icon class', () => {
+        comp.disabled = true;
+        fixture.detectChanges();
+
+        expect(icon.classList.contains('test')).toBeTruthy();
+    });
+});

--- a/src/ngx-gallery-action.component.ts
+++ b/src/ngx-gallery-action.component.ts
@@ -1,0 +1,25 @@
+import { ChangeDetectionStrategy, Component, Input, Output, EventEmitter } from '@angular/core';
+
+@Component({
+    selector: 'ngx-gallery-action',
+    template: `
+        <i class="ngx-gallery-icon {{ icon }}" [class.ngx-gallery-icon-disabled]="disabled"
+            aria-hidden="true"
+            title="{{ titleText }}"
+            (click)="handleClick($event)">
+        </i>`,
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class NgxGalleryActionComponent {
+    @Input() icon: string;
+    @Input() disabled = false;
+    @Input() titleText = '';
+
+    @Output() onClick: EventEmitter<Event> = new EventEmitter();
+
+    handleClick(event: Event) {
+        if (!this.disabled) {
+            this.onClick.emit(event);
+        }
+    }
+}

--- a/src/ngx-gallery-action.model.ts
+++ b/src/ngx-gallery-action.model.ts
@@ -1,0 +1,23 @@
+export interface INgxGalleryAction {
+    icon: string;
+    disabled?: boolean;
+    titleText?: string;
+
+    onClick: (event: Event) => void;
+}
+
+export class NgxGalleryAction implements INgxGalleryAction {
+    icon: string;
+    disabled?: boolean;
+    titleText?: string;
+
+    onClick: (event: Event) => void;
+
+    constructor(action: INgxGalleryAction) {
+        this.icon = action.icon;
+        this.disabled = action.disabled ? action.disabled : false;
+        this.titleText = action.titleText ? action.titleText : '';
+
+        this.onClick = action.onClick;
+    }
+}

--- a/src/ngx-gallery-arrows.component.spec.ts
+++ b/src/ngx-gallery-arrows.component.spec.ts
@@ -1,6 +1,6 @@
 import {} from 'jasmine';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
-import { NgxGalleryArrowsComponent } from "./";
+import { NgxGalleryArrowsComponent } from './';
 
 describe('NgxGalleryArrowsComponent', () => {
     let fixture: ComponentFixture<NgxGalleryArrowsComponent>;

--- a/src/ngx-gallery-image.component.spec.ts
+++ b/src/ngx-gallery-image.component.spec.ts
@@ -1,9 +1,9 @@
 import {} from 'jasmine';
-import { Renderer, SimpleChange } from '@angular/core';
+import { Renderer } from '@angular/core';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { HammerGestureConfig, HAMMER_GESTURE_CONFIG } from '@angular/platform-browser';
 import { NgxGalleryImageComponent, NgxGalleryArrowsComponent, NgxGalleryHelperService,
-    NgxGalleryOrderedImage } from "./";
+    NgxGalleryOrderedImage } from './';
 
 export class CustomHammerConfig extends HammerGestureConfig  {
     overrides = <any>{

--- a/src/ngx-gallery-image.component.ts
+++ b/src/ngx-gallery-image.component.ts
@@ -89,7 +89,7 @@ export class NgxGalleryImageComponent implements OnInit, OnChanges {
 
             if (prevIndex === -1 && this.infinityMove) {
                 indexes.push(this.images.length - 1)
-            } else if(prevIndex >= 0) {
+            } else if (prevIndex >= 0) {
                 indexes.push(prevIndex);
             }
 

--- a/src/ngx-gallery-options.model.ts
+++ b/src/ngx-gallery-options.model.ts
@@ -2,14 +2,7 @@ import { NgxGalleryAnimation } from './ngx-gallery-animation.model';
 import { NgxGalleryImageSize } from './ngx-gallery-image-size.model';
 import { NgxGalleryLayout } from './ngx-gallery-layout.model';
 import { NgxGalleryOrder } from './ngx-gallery-order.model';
-
-export interface INgxGalleryAction {
-    icon: string;
-    disabled?: boolean;
-    titleText?: string;
-
-    onClick: (event: Event) => void;
-}
+import { NgxGalleryAction } from './ngx-gallery-action.model';
 
 export interface INgxGalleryOptions {
     width?: string;
@@ -68,7 +61,7 @@ export interface INgxGalleryOptions {
     spinnerIcon?: string;
     zoomInIcon?: string;
     zoomOutIcon?: string;
-    actions?: INgxGalleryAction[];
+    actions?: NgxGalleryAction[];
 }
 
 export class NgxGalleryOptions implements INgxGalleryOptions {
@@ -128,7 +121,7 @@ export class NgxGalleryOptions implements INgxGalleryOptions {
     spinnerIcon?: string;
     zoomInIcon?: string;
     zoomOutIcon?: string;
-    actions?: INgxGalleryAction[];
+    actions?: NgxGalleryAction[];
 
     constructor(obj: INgxGalleryOptions) {
 
@@ -199,6 +192,9 @@ export class NgxGalleryOptions implements INgxGalleryOptions {
         this.zoomInIcon = use(obj.zoomInIcon, 'fa fa-search-plus');
         this.zoomOutIcon = use(obj.zoomOutIcon, 'fa fa-search-minus');
 
+        if (obj && obj.actions && obj.actions.length) {
+            obj.actions = obj.actions.map(action => new NgxGalleryAction(action));
+        }
         this.actions = use(obj.actions, []);
     }
 }

--- a/src/ngx-gallery-options.model.ts
+++ b/src/ngx-gallery-options.model.ts
@@ -3,6 +3,14 @@ import { NgxGalleryImageSize } from './ngx-gallery-image-size.model';
 import { NgxGalleryLayout } from './ngx-gallery-layout.model';
 import { NgxGalleryOrder } from './ngx-gallery-order.model';
 
+export interface INgxGalleryAction {
+    icon: string;
+    disabled?: boolean;
+    titleText?: string;
+
+    onClick: (event: Event) => void;
+}
+
 export interface INgxGalleryOptions {
     width?: string;
     height?: string;
@@ -60,6 +68,7 @@ export interface INgxGalleryOptions {
     spinnerIcon?: string;
     zoomInIcon?: string;
     zoomOutIcon?: string;
+    actions?: INgxGalleryAction[];
 }
 
 export class NgxGalleryOptions implements INgxGalleryOptions {
@@ -119,6 +128,7 @@ export class NgxGalleryOptions implements INgxGalleryOptions {
     spinnerIcon?: string;
     zoomInIcon?: string;
     zoomOutIcon?: string;
+    actions?: INgxGalleryAction[];
 
     constructor(obj: INgxGalleryOptions) {
 
@@ -146,7 +156,7 @@ export class NgxGalleryOptions implements INgxGalleryOptions {
         this.imageSize = use(obj.imageSize, NgxGalleryImageSize.Cover);
         this.imageAutoPlay = use(obj.imageAutoPlay, false);
         this.imageAutoPlayInterval = use(obj.imageAutoPlayInterval, 2000);
-        this.imageAutoPlayPauseOnHover= use(obj.imageAutoPlayPauseOnHover, false);
+        this.imageAutoPlayPauseOnHover = use(obj.imageAutoPlayPauseOnHover, false);
         this.imageInfinityMove = use(obj.imageInfinityMove, false);
 
         this.thumbnails = use(obj.thumbnails, true);
@@ -188,5 +198,7 @@ export class NgxGalleryOptions implements INgxGalleryOptions {
         this.spinnerIcon = use(obj.spinnerIcon, 'fa fa-spinner fa-pulse fa-3x fa-fw');
         this.zoomInIcon = use(obj.zoomInIcon, 'fa fa-search-plus');
         this.zoomOutIcon = use(obj.zoomOutIcon, 'fa fa-search-minus');
+
+        this.actions = use(obj.actions, []);
     }
 }

--- a/src/ngx-gallery-preview.component.scss
+++ b/src/ngx-gallery-preview.component.scss
@@ -2,8 +2,8 @@
     width: 100%;
     height: 100%;
     position: fixed;
-    left: 0px;
-    top: 0px;
+    left: 0;
+    top: 0;
     background: rgba(0, 0, 0, 0.7);
     z-index: 10000;
     display: inline-block;
@@ -36,30 +36,30 @@
 
 .ngx-gallery-icon.ngx-gallery-spinner {
     font-size: 50px;
-    left: 0px;
+    left: 0;
     display: inline-block;
 }
 
-.ngx-gallery-preview-top {
+:host /deep/ .ngx-gallery-preview-top {
     position: absolute;
     width: 100%;
     user-select: none;
 }
 
-.ngx-gallery-preview-icons {
+:host /deep/ .ngx-gallery-preview-icons {
     float: right;
-}
 
-.ngx-gallery-preview-icons .ngx-gallery-icon {
-    position: relative;
-    margin-right: 10px;
-    margin-top: 10px;
-    font-size: 25px;
-    cursor: pointer;
+    .ngx-gallery-icon {
+        position: relative;
+        margin-right: 10px;
+        margin-top: 10px;
+        font-size: 25px;
+        cursor: pointer;
 
-    &.ngx-gallery-icon-disabled {
-        cursor: default;
-        opacity: 0.4;
+        &.ngx-gallery-icon-disabled {
+            cursor: default;
+            opacity: 0.4;
+        }
     }
 }
 

--- a/src/ngx-gallery-preview.component.spec.ts
+++ b/src/ngx-gallery-preview.component.spec.ts
@@ -1,7 +1,8 @@
 import {} from 'jasmine';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { Renderer, SimpleChange } from '@angular/core';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
-import { NgxGalleryPreviewComponent, NgxGalleryArrowsComponent, NgxGalleryHelperService } from "./";
+import { NgxGalleryActionComponent, NgxGalleryPreviewComponent, NgxGalleryArrowsComponent, NgxGalleryHelperService } from './';
 
 describe('NgxGalleryPreviewComponent', () => {
     let fixture: ComponentFixture<NgxGalleryPreviewComponent>;
@@ -10,7 +11,7 @@ describe('NgxGalleryPreviewComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-          declarations: [ NgxGalleryPreviewComponent, NgxGalleryArrowsComponent ],
+            declarations: [ NgxGalleryPreviewComponent, NgxGalleryArrowsComponent, NgxGalleryActionComponent ],
           providers: [ NgxGalleryHelperService, Renderer ]
         })
         .overrideComponent(NgxGalleryPreviewComponent, {
@@ -168,6 +169,41 @@ describe('NgxGalleryPreviewComponent', () => {
             expect(image.getAttribute('src')).toEqual('image-2.jpg');
             done();
         }, 1000)
+    });
+
+    it('should trigger change event on show next', () => {
+        spyOn(comp.onActiveChange, 'emit');
+
+        comp.showNext();
+        expect(comp.onActiveChange.emit).toHaveBeenCalled();
+    });
+
+    it('should trigger change event on show previous', () => {
+        spyOn(comp.onActiveChange, 'emit');
+        comp.open(1);
+        comp.loading = false;
+
+        comp.showPrev();
+        expect(comp.onActiveChange.emit).toHaveBeenCalled();
+    });
+
+    it('should emit change events during autoplay', (done) => {
+        spyOn(comp.onActiveChange, 'emit');
+
+        comp.autoPlay = true;
+        comp.autoPlayInterval = 1;
+        comp.autoPlayPauseOnHover = true;
+        comp.open(0);
+        comp.loading = false;
+
+        image.dispatchEvent(new Event('mouseenter'));
+        image.dispatchEvent(new Event('mouseleave'));
+
+        setTimeout(() => {
+            fixture.detectChanges();
+            expect(comp.onActiveChange.emit).toHaveBeenCalledTimes(2);
+            done();
+        }, 1000);
     });
 
     // it('should close on escape', (done) => {

--- a/src/ngx-gallery-preview.component.ts
+++ b/src/ngx-gallery-preview.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges, ElementRef, HostListener, ViewChild } from '@angular/core';
 import { SafeResourceUrl, DomSanitizer, SafeUrl } from '@angular/platform-browser';
 
+import { INgxGalleryAction } from './ngx-gallery-options.model';
 import { NgxGalleryHelperService } from './ngx-gallery-helper.service';
 
 @Component({
@@ -9,10 +10,11 @@ import { NgxGalleryHelperService } from './ngx-gallery-helper.service';
         <ngx-gallery-arrows (onPrevClick)="showPrev()" (onNextClick)="showNext()" [prevDisabled]="!canShowPrev()" [nextDisabled]="!canShowNext()" [arrowPrevIcon]="arrowPrevIcon" [arrowNextIcon]="arrowNextIcon"></ngx-gallery-arrows>
         <div class="ngx-gallery-preview-top">
             <div class="ngx-gallery-preview-icons">
-                <i class="ngx-gallery-icon {{zoomOutIcon}}" aria-hidden="true" (click)="zoomOut()" *ngIf="zoom" [class.ngx-gallery-icon-disabled]="!canZoomOut()"></i>
-                <i class="ngx-gallery-icon {{zoomInIcon}}" aria-hidden="true" (click)="zoomIn()" *ngIf="zoom" [class.ngx-gallery-icon-disabled]="!canZoomIn()"></i>
-                <i class="ngx-gallery-icon ngx-gallery-fullscreen {{fullscreenIcon}}" aria-hidden="true" *ngIf="fullscreen" (click)="manageFullscreen()"></i>
-                <i class="ngx-gallery-icon ngx-gallery-close {{closeIcon}}" aria-hidden="true" (click)="close()"></i>
+                <ngx-gallery-action *ngFor="let action of actions" [icon]="action.icon" [disabled]="action.disabled" [titleText]="action.titleText" (onClick)="action.onClick($event)"></ngx-gallery-action>
+                <ngx-gallery-action *ngIf="zoom" [icon]="zoomOutIcon" [disabled]="!canZoomOut()" (onClick)="zoomOut()"></ngx-gallery-action>
+                <ngx-gallery-action *ngIf="zoom" [icon]="zoomInIcon" [disabled]="!canZoomIn()" (onClick)="zoomIn()"></ngx-gallery-action>
+                <ngx-gallery-action *ngIf="fullscreen" [icon]="'ngx-gallery-fullscreen ' + fullscreenIcon" (onClick)="manageFullscreen()"></ngx-gallery-action>
+                <ngx-gallery-action [icon]="'ngx-gallery-close ' + closeIcon" (onClick)="close()"></ngx-gallery-action>
             </div>
         </div>
         <div class="ngx-spinner-wrapper ngx-gallery-center" [class.ngx-gallery-active]="showSpinner">
@@ -62,9 +64,11 @@ export class NgxGalleryPreviewComponent implements OnChanges {
     @Input() zoomMin: number;
     @Input() zoomInIcon: string;
     @Input() zoomOutIcon: string;
+    @Input() actions: INgxGalleryAction[];
 
     @Output() onOpen = new EventEmitter();
     @Output() onClose = new EventEmitter();
+    @Output() onActiveChange = new EventEmitter<number>();
 
     @ViewChild('previewImage') previewImage: ElementRef;
 
@@ -237,7 +241,7 @@ export class NgxGalleryPreviewComponent implements OnChanges {
                 this.zoomValue = this.zoomMin;
             }
 
-            if(this.zoomValue <= 1) {
+            if (this.zoomValue <= 1) {
                 this.resetPosition()
             }
         }
@@ -334,9 +338,11 @@ export class NgxGalleryPreviewComponent implements OnChanges {
         }
     }
 
-    private show(first: boolean = false) {
+    private show(first = false) {
         this.loading = true;
         this.stopAutoPlay();
+
+        this.onActiveChange.emit(this.index);
 
         if (first) {
             this._show();
@@ -379,7 +385,7 @@ export class NgxGalleryPreviewComponent implements OnChanges {
             return false;
         }
 
-        if (typeof img.naturalWidth !== "undefined" && img.naturalWidth === 0) {
+        if (typeof img.naturalWidth !== 'undefined' && img.naturalWidth === 0) {
             return false;
         }
 

--- a/src/ngx-gallery-preview.component.ts
+++ b/src/ngx-gallery-preview.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges, ElementRef, HostListener, ViewChild } from '@angular/core';
 import { SafeResourceUrl, DomSanitizer, SafeUrl } from '@angular/platform-browser';
 
-import { INgxGalleryAction } from './ngx-gallery-options.model';
+import { NgxGalleryAction } from './ngx-gallery-action.model';
 import { NgxGalleryHelperService } from './ngx-gallery-helper.service';
 
 @Component({
@@ -64,7 +64,7 @@ export class NgxGalleryPreviewComponent implements OnChanges {
     @Input() zoomMin: number;
     @Input() zoomInIcon: string;
     @Input() zoomOutIcon: string;
-    @Input() actions: INgxGalleryAction[];
+    @Input() actions: NgxGalleryAction[];
 
     @Output() onOpen = new EventEmitter();
     @Output() onClose = new EventEmitter();

--- a/src/ngx-gallery-thumbnails.component.spec.ts
+++ b/src/ngx-gallery-thumbnails.component.spec.ts
@@ -1,7 +1,7 @@
 import {} from 'jasmine';
 import { Renderer, SimpleChange } from '@angular/core';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
-import { NgxGalleryThumbnailsComponent, NgxGalleryArrowsComponent, NgxGalleryHelperService } from "./";
+import { NgxGalleryThumbnailsComponent, NgxGalleryArrowsComponent, NgxGalleryHelperService } from './';
 
 describe('NgxGalleryThumbnailsComponent', () => {
     let fixture: ComponentFixture<NgxGalleryThumbnailsComponent>;

--- a/src/ngx-gallery-thumbnails.component.ts
+++ b/src/ngx-gallery-thumbnails.component.ts
@@ -92,8 +92,7 @@ export class NgxGalleryThumbnailsComponent implements OnChanges {
     getImages(): string[] | SafeResourceUrl[] {
         if (this.remainingCount) {
             return this.images.slice(0, this.columns);
-        }
-        else if (this.lazyLoading && this.order != NgxGalleryOrder.Row) {
+        } else if (this.lazyLoading && this.order != NgxGalleryOrder.Row) {
             let stopIndex = this.index + this.columns + this.moveSize;
 
             if (this.rows > 1 && this.order === NgxGalleryOrder.Column) {
@@ -107,8 +106,7 @@ export class NgxGalleryThumbnailsComponent implements OnChanges {
             }
 
             return this.images.slice(0, stopIndex);
-        }
-        else {
+        } else {
             return this.images;
         }
     }
@@ -132,7 +130,7 @@ export class NgxGalleryThumbnailsComponent implements OnChanges {
             this.index += this.moveSize;
             let maxIndex = this.getMaxIndex() - this.columns;
 
-            if(this.index > maxIndex) {
+            if (this.index > maxIndex) {
                 this.index = maxIndex;
             }
 
@@ -142,7 +140,7 @@ export class NgxGalleryThumbnailsComponent implements OnChanges {
 
     moveLeft(): void {
         if (this.canMoveLeft()) {
-            this.index-= this.moveSize;
+            this.index -= this.moveSize;
 
             if (this.index < 0) {
                 this.index = 0;

--- a/src/ngx-gallery.component.spec.ts
+++ b/src/ngx-gallery.component.spec.ts
@@ -1,10 +1,12 @@
 import { NgxGalleryImage } from './ngx-gallery-image.model';
-import {} from 'jasmine';
+import { } from 'jasmine';
 import { Renderer, SimpleChange } from '@angular/core';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
-import { NgxGalleryComponent, NgxGalleryImageComponent, NgxGalleryThumbnailsComponent,
-     NgxGalleryPreviewComponent, NgxGalleryArrowsComponent,NgxGalleryHelperService,
-     NgxGalleryOptions } from "./";
+import {
+    NgxGalleryComponent, NgxGalleryActionComponent, NgxGalleryImageComponent, NgxGalleryThumbnailsComponent,
+    NgxGalleryPreviewComponent, NgxGalleryArrowsComponent, NgxGalleryHelperService,
+    NgxGalleryOptions
+} from './';
 
 describe('NgxGalleryComponent', () => {
     let fixture: ComponentFixture<NgxGalleryComponent>;
@@ -13,15 +15,15 @@ describe('NgxGalleryComponent', () => {
 
     beforeEach(() => {
         TestBed.configureTestingModule({
-          declarations: [ NgxGalleryComponent, NgxGalleryThumbnailsComponent,
-            NgxGalleryImageComponent, NgxGalleryPreviewComponent, NgxGalleryArrowsComponent ],
-          providers: [ NgxGalleryHelperService, Renderer ]
+            declarations: [ NgxGalleryComponent, NgxGalleryActionComponent, NgxGalleryThumbnailsComponent,
+                NgxGalleryImageComponent, NgxGalleryPreviewComponent, NgxGalleryArrowsComponent ],
+            providers: [ NgxGalleryHelperService, Renderer ]
         })
-        .overrideComponent(NgxGalleryComponent, {
-            set: {
-                styleUrls: [],
-            }
-        })
+            .overrideComponent(NgxGalleryComponent, {
+                set: {
+                    styleUrls: [],
+                }
+            })
 
         fixture = TestBed.createComponent(NgxGalleryComponent);
         comp = fixture.componentInstance;
@@ -43,7 +45,7 @@ describe('NgxGalleryComponent', () => {
                 big: 'assets/3-big.jpg'
             })
         ];
-        comp.options = [new NgxGalleryOptions({})];
+        comp.options = [ new NgxGalleryOptions({}) ];
         fixture.detectChanges();
 
         el = fixture.debugElement.nativeElement;

--- a/src/ngx-gallery.component.ts
+++ b/src/ngx-gallery.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, HostListener, ViewChild, OnInit,
-    HostBinding, DoCheck, ElementRef, AfterViewInit, Output, EventEmitter, Inject } from '@angular/core';
+    HostBinding, DoCheck, ElementRef, AfterViewInit, Output, EventEmitter } from '@angular/core';
 import { SafeResourceUrl } from '@angular/platform-browser';
 
 import { NgxGalleryPreviewComponent } from './ngx-gallery-preview.component';
@@ -20,7 +20,7 @@ import { NgxGalleryOrderedImage } from './ngx-gallery-ordered-image.model';
 
         <ngx-gallery-thumbnails *ngIf="currentOptions?.thumbnails" [style.marginTop]="getThumbnailsMarginTop()" [style.marginBottom]="getThumbnailsMarginBottom()" [style.height]="getThumbnailsHeight()" [images]="smallImages" [links]="currentOptions?.thumbnailsAsLinks ? links : []" [linkTarget]="currentOptions?.linkTarget" [selectedIndex]="selectedIndex" [columns]="currentOptions?.thumbnailsColumns" [rows]="currentOptions?.thumbnailsRows" [margin]="currentOptions?.thumbnailMargin" [arrows]="currentOptions?.thumbnailsArrows" [arrowsAutoHide]="currentOptions?.thumbnailsArrowsAutoHide" [arrowPrevIcon]="currentOptions?.arrowPrevIcon" [arrowNextIcon]="currentOptions?.arrowNextIcon" [clickable]="currentOptions?.image || currentOptions?.preview" [swipe]="currentOptions?.thumbnailsSwipe" [size]="currentOptions?.thumbnailSize" [moveSize]="currentOptions?.thumbnailsMoveSize" [order]="currentOptions?.thumbnailsOrder" [remainingCount]="currentOptions?.thumbnailsRemainingCount" [lazyLoading]="currentOptions?.lazyLoading" (onActiveChange)="selectFromThumbnails($event)"></ngx-gallery-thumbnails>
 
-        <ngx-gallery-preview [images]="bigImages" [descriptions]="descriptions" [showDescription]="currentOptions?.previewDescription" [arrowPrevIcon]="currentOptions?.arrowPrevIcon" [arrowNextIcon]="currentOptions?.arrowNextIcon" [closeIcon]="currentOptions?.closeIcon" [fullscreenIcon]="currentOptions?.fullscreenIcon" [spinnerIcon]="currentOptions?.spinnerIcon" [swipe]="currentOptions?.previewSwipe" [fullscreen]="currentOptions?.previewFullscreen" [forceFullscreen]="currentOptions?.previewForceFullscreen" [closeOnClick]="currentOptions?.previewCloseOnClick" [closeOnEsc]="currentOptions?.previewCloseOnEsc" [keyboardNavigation]="currentOptions?.previewKeyboardNavigation" [autoPlay]="currentOptions?.previewAutoPlay" [autoPlayInterval]="currentOptions?.previewAutoPlayInterval" [autoPlayPauseOnHover]="currentOptions?.previewAutoPlayPauseOnHover" [infinityMove]="currentOptions?.previewInfinityMove" [zoom]="currentOptions?.previewZoom" [zoomStep]="currentOptions?.previewZoomStep" [zoomMax]="currentOptions?.previewZoomMax" [zoomMin]="currentOptions?.previewZoomMin" [zoomInIcon]="currentOptions?.zoomInIcon" [zoomOutIcon]="currentOptions?.zoomOutIcon" (onClose)="onPreviewClose()" (onOpen)="onPreviewOpen()" [class.ngx-gallery-active]="previewEnabled"></ngx-gallery-preview>
+        <ngx-gallery-preview [images]="bigImages" [descriptions]="descriptions" [showDescription]="currentOptions?.previewDescription" [arrowPrevIcon]="currentOptions?.arrowPrevIcon" [arrowNextIcon]="currentOptions?.arrowNextIcon" [closeIcon]="currentOptions?.closeIcon" [fullscreenIcon]="currentOptions?.fullscreenIcon" [spinnerIcon]="currentOptions?.spinnerIcon" [swipe]="currentOptions?.previewSwipe" [fullscreen]="currentOptions?.previewFullscreen" [forceFullscreen]="currentOptions?.previewForceFullscreen" [closeOnClick]="currentOptions?.previewCloseOnClick" [closeOnEsc]="currentOptions?.previewCloseOnEsc" [keyboardNavigation]="currentOptions?.previewKeyboardNavigation" [autoPlay]="currentOptions?.previewAutoPlay" [autoPlayInterval]="currentOptions?.previewAutoPlayInterval" [autoPlayPauseOnHover]="currentOptions?.previewAutoPlayPauseOnHover" [infinityMove]="currentOptions?.previewInfinityMove" [zoom]="currentOptions?.previewZoom" [zoomStep]="currentOptions?.previewZoomStep" [zoomMax]="currentOptions?.previewZoomMax" [zoomMin]="currentOptions?.previewZoomMin" [zoomInIcon]="currentOptions?.zoomInIcon" [zoomOutIcon]="currentOptions?.zoomOutIcon" [actions]="currentOptions?.actions" (onClose)="onPreviewClose()" (onOpen)="onPreviewOpen()" (onActiveChange)="previewSelect($event)" [class.ngx-gallery-active]="previewEnabled"></ngx-gallery-preview>
     </div>
     `,
     styleUrls: ['./ngx-gallery.component.scss'],
@@ -31,9 +31,10 @@ export class NgxGalleryComponent implements OnInit, DoCheck, AfterViewInit   {
     @Input() images: NgxGalleryImage[];
 
     @Output() imagesReady = new EventEmitter();
-    @Output() change = new EventEmitter();
+    @Output() change = new EventEmitter<{ index: number; image: NgxGalleryImage; }>();
     @Output() previewOpen = new EventEmitter();
     @Output() previewClose = new EventEmitter();
+    @Output() previewChange = new EventEmitter<{ index: number; image: NgxGalleryImage; }>();
 
     smallImages: string[] | SafeResourceUrl[];
     mediumImages: NgxGalleryOrderedImage[];
@@ -219,6 +220,10 @@ export class NgxGalleryComponent implements OnInit, DoCheck, AfterViewInit   {
             index,
             image: this.images[index]
         });
+    }
+
+    private previewSelect(index: number) {
+        this.previewChange.emit({index, image: this.images[index]});
     }
 
     private checkFullWidth(): void {

--- a/src/ngx-gallery.spec.ts
+++ b/src/ngx-gallery.spec.ts
@@ -1,6 +1,6 @@
 // import {} from 'jasmine';
 // import { TestBed, inject, async } from '@angular/core/testing';
-// import { NgxGalleryModule } from "./";
+// import { NgxGalleryModule } from './';
 
 // describe('NgxGallery', () => {
 //     beforeEach(() => {


### PR DESCRIPTION
Demo: https://plnkr.co/edit/JnH9qSrnetcxxmDRPZDq?p=preview

This PR adds the ability to pass in options for adding icons to the left of the close, zoom, and fullscreen icons that can be used to perform custom actions via an Output.
Additionally, it adds a `previewChange` event that fires whenever a new photo is shown in the preview, very similarly to the `change` event.
I also fixed a few linting errors that my editor was yelling about. 

Take a look and let me know what you think, I'm more than open to suggestions.