### PR TITLE
add previewCustom option

### DIFF
--- a/src/ngx-gallery-options.model.ts
+++ b/src/ngx-gallery-options.model.ts
@@ -59,6 +59,7 @@ export interface INgxGalleryOptions {
     previewZoomMax?: number;
     previewZoomMin?: number;
     previewRotate?: boolean;
+    previewCustom?: (index: number) => void;
     arrowPrevIcon?: string;
     arrowNextIcon?: string;
     closeIcon?: string;
@@ -126,6 +127,7 @@ export class NgxGalleryOptions implements INgxGalleryOptions {
     previewZoomMax?: number;
     previewZoomMin?: number;
     previewRotate?: boolean;
+    previewCustom?: (index: number) => void;
     arrowPrevIcon?: string;
     arrowNextIcon?: string;
     closeIcon?: string;
@@ -208,6 +210,7 @@ export class NgxGalleryOptions implements INgxGalleryOptions {
         this.previewZoomMax = use(obj.previewZoomMax, 2);
         this.previewZoomMin = use(obj.previewZoomMin, 0.5);
         this.previewRotate = use(obj.previewRotate, false);
+        this.previewCustom = use(obj.previewCustom, undefined);
 
         this.arrowPrevIcon = use(obj.arrowPrevIcon, 'fa fa-arrow-circle-left');
         this.arrowNextIcon = use(obj.arrowNextIcon, 'fa fa-arrow-circle-right');

--- a/src/ngx-gallery.component.ts
+++ b/src/ngx-gallery.component.ts
@@ -150,8 +150,12 @@ export class NgxGalleryComponent implements OnInit, DoCheck, AfterViewInit   {
     }
 
     openPreview(index: number): void {
-        this.previewEnabled = true;
-        this.preview.open(index);
+        if (this.currentOptions.previewCustom) {
+            this.currentOptions.previewCustom(index);
+        } else {
+            this.previewEnabled = true;
+            this.preview.open(index);
+        }
     }
 
     onPreviewOpen(): void {


### PR DESCRIPTION
This allows to implement a custom preview callback to override default behavior (for example on mobile device). Works with breakpoints.

Example: 
```
this.galleryOptions = [
            {
                width: '100%', preview: true,
                imageArrows: false, thumbnailsSwipe: true,
                imageSwipe: true, 
                previewCloseOnEsc: true, previewCloseOnClick: true
            },
            { breakpoint: 800, height: "400px", thumbnailsColumns: 4, thumbnailsMoveSize: 4, previewCustom: this.openPreview.bind(this) },
            { breakpoint: 1200, height: "600px", thumbnailsColumns: 5, thumbnailsMoveSize: 5 },
            { breakpoint: 2000, height: "1024px", thumbnailsColumns: 6, thumbnailsMoveSize: 6 },
        ];
```
