### PR TITLE
Fix choppy transitions in Chrome

### DIFF
--- a/src/ngx-gallery-thumbnails.component.scss
+++ b/src/ngx-gallery-thumbnails.component.scss
@@ -16,7 +16,9 @@
     width: 100%;
     position: absolute;
     left: 0px;
-    transition: left 0.5s ease-in-out;
+    transform: translateX(0);
+    transition: transform 0.5s ease-in-out;
+    will-change: transform;
 
     .ngx-gallery-thumbnail {
         position: absolute;

--- a/src/ngx-gallery-thumbnails.component.spec.ts
+++ b/src/ngx-gallery-thumbnails.component.spec.ts
@@ -40,7 +40,7 @@ describe('NgxGalleryThumbnailsComponent', () => {
         comp.moveRight();
         fixture.detectChanges();
 
-        expect(thumbnails.getAttribute('style')).toEqual('left: -50%; margin-left: -5px;');
+        expect(thumbnails.getAttribute('style')).toEqual('transform: translateX(-50%); margin-left: -5px;');
     });
 
     it('should show prev images', () => {
@@ -49,7 +49,7 @@ describe('NgxGalleryThumbnailsComponent', () => {
         comp.moveLeft();
         fixture.detectChanges();
 
-        expect(thumbnails.getAttribute('style')).toEqual('left: 0%; margin-left: 0px;');
+        expect(thumbnails.getAttribute('style')).toEqual('transform: translateX(0%); margin-left: 0px;');
     });
 
     it('should validate selected index after selected index change', () => {
@@ -62,7 +62,7 @@ describe('NgxGalleryThumbnailsComponent', () => {
 
         fixture.detectChanges();
 
-        expect(thumbnails.getAttribute('style')).toEqual('left: -50%; margin-left: -5px;');
+        expect(thumbnails.getAttribute('style')).toEqual('transform: translateX(-50%); margin-left: -5px;');
     });
 
     it('should emit event onActiveChange after click on image', (done) => {

--- a/src/ngx-gallery-thumbnails.component.ts
+++ b/src/ngx-gallery-thumbnails.component.ts
@@ -9,7 +9,7 @@ import { NgxGalleryAction } from './ngx-gallery-action.model';
     selector: 'ngx-gallery-thumbnails',
     template: `
     <div class="ngx-gallery-thumbnails-wrapper ngx-gallery-thumbnail-size-{{size}}">
-        <div class="ngx-gallery-thumbnails" [style.left]="thumbnailsLeft" [style.marginLeft]="thumbnailsMarginLeft">
+        <div class="ngx-gallery-thumbnails" [style.transform]="'translateX(' + thumbnailsLeft + ')'" [style.marginLeft]="thumbnailsMarginLeft">
             <a [href]="hasLinks() ? links[i] : '#'" [target]="linkTarget" class="ngx-gallery-thumbnail" *ngFor="let image of getImages(); let i = index;" [style.background-image]="getSafeUrl(image)" (click)="handleClick($event, i)" [style.width]="getThumbnailWidth()" [style.height]="getThumbnailHeight()" [style.left]="getThumbnailLeft(i)" [style.top]="getThumbnailTop(i)" [ngClass]="{ 'ngx-gallery-active': i == selectedIndex, 'ngx-gallery-clickable': clickable }" [attr.aria-label]="labels[i]">
                 <div class="ngx-gallery-icons-wrapper">
                     <ngx-gallery-action *ngFor="let action of actions" [icon]="action.icon" [disabled]="action.disabled" [titleText]="action.titleText" (onClick)="action.onClick($event, i)"></ngx-gallery-action>


### PR DESCRIPTION
Me and my team currently use this gallery in our project. When we were testing it we used big images and when we tried to scroll through the thumbnails we noticed that transition animation is quite choppy on Chrome browser. This is the fix for it. Basically, using top/left/right/bottom in a transition is bad. When you want to animate element's position you should use translateX/Y.

> Where you can, you should avoid animating properties that trigger layout or paint. For most modern browsers, this means limiting animations to opacity or transform, both of which the browser can highly optimize; it doesn’t matter if the animation is handled by JavaScript or CSS.
https://developers.google.com/web/fundamentals/design-and-ux/animations/animations-and-performance