### PR TITLE
added tsconfig file for es2015 target and used it in gulpfile.js .

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -44,14 +44,13 @@ gulp.task('inline-resources', function () {
     .then(() => inlineResources(tmpFolder));
 });
 
-
 /**
  * 4. Run the Angular compiler, ngc, on the /.tmp folder. This will output all
  *    compiled modules to the /build folder.
  */
 gulp.task('ngc', function () {
   return ngc({
-    project: `${tmpFolder}/tsconfig.es5.json`
+    project: `${tmpFolder}/tsconfig.es2015.json`
   })
     .then((exitCode) => {
       if (exitCode === 1) {

--- a/src/tsconfig.es2015.json
+++ b/src/tsconfig.es2015.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "module": "esnext",
+    "target": "es2015",
+    "baseUrl": ".",
+    "stripInternal": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "moduleResolution": "node",
+    "outDir": "../build",
+    "rootDir": ".",
+    "lib": [
+      "es2015",
+      "dom"
+    ],
+    "skipLibCheck": true,
+    "types": []
+  },
+  "angularCompilerOptions": {
+    "annotateForClosureCompiler": true,
+    "strictMetadataEmit": true,
+    "skipTemplateCodegen": true,
+    "flatModuleOutFile": "ngx-gallery.js",
+    "flatModuleId": "ngx-gallery"
+  },
+  "files": [
+    "./index.ts"
+  ]
+}


### PR DESCRIPTION
Added solution from #242 (referenced in #271) in project by modifying the tsconfig.es5 file (made a copy named tsconfig.es2015.js and used it in gulpfile).
As mentioned in my comment in #242 I am not shure if this kills any es5 app.
Any idea how to test this?