### PR TITLE
Update ngx-gallery-preview.component.ts

### DIFF
--- a/src/ngx-gallery-preview.component.ts
+++ b/src/ngx-gallery-preview.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, Input, Output, EventEmitter, OnInit, OnChanges, SimpleChanges, ElementRef, HostListener, ViewChild, Renderer } from '@angular/core';
+import { ChangeDetectorRef, Component, Input, Output, EventEmitter, OnInit, OnChanges, SimpleChanges, ElementRef, HostListener, ViewChild, Renderer2 } from '@angular/core';
 import { SafeResourceUrl, DomSanitizer, SafeUrl, SafeStyle } from '@angular/platform-browser';
 
 import { NgxGalleryAction } from './ngx-gallery-action.model';


### PR DESCRIPTION
fix the following issue:
node_modules/ngx-gallery/ngx-gallery-preview.component.d.ts:1:89 - error TS2724: Module '"../@angular/core/core"' has no exported member 'Renderer'. Did you mean 'Renderer2'?