### PR TITLE
Update ngx-gallery-preview.component.ts

### DIFF
--- a/src/ngx-gallery-preview.component.ts
+++ b/src/ngx-gallery-preview.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, Input, Output, EventEmitter, OnInit, OnChanges, SimpleChanges, ElementRef, HostListener, ViewChild, Renderer } from '@angular/core';
+import { ChangeDetectorRef, Component, Input, Output, EventEmitter, OnInit, OnChanges, SimpleChanges, ElementRef, HostListener, ViewChild, Renderer2 } from '@angular/core';
 import { SafeResourceUrl, DomSanitizer, SafeUrl, SafeStyle } from '@angular/platform-browser';
 
 import { NgxGalleryAction } from './ngx-gallery-action.model';
@@ -100,7 +100,7 @@ export class NgxGalleryPreviewComponent implements OnInit, OnChanges {
     private keyDownListener: Function;
 
     constructor(private sanitization: DomSanitizer, private elementRef: ElementRef,
-        private helperService: NgxGalleryHelperService, private renderer: Renderer,
+        private helperService: NgxGalleryHelperService, private renderer: Renderer2,
         private changeDetectorRef: ChangeDetectorRef) {}
 
     ngOnInit(): void {


### PR DESCRIPTION
all Renderer(s) should be changed to Renderer2


p.s.
This module has several incompatibilities with Angular 9+ that need to be addressed properly. Renderer2 is one of them.
I would happily fix them if I wasn't so busy.